### PR TITLE
Various criteria for selecting the committee to return

### DIFF
--- a/examples/introspection/algorithms_multigoal.py
+++ b/examples/introspection/algorithms_multigoal.py
@@ -16,9 +16,10 @@ candidates = [0, 1, 2]
 
 profile = Profile(candidates, preferences)
 
-# rule = MultigoalCCBorda((8, 8))
-rule = MultigoalTBloc((2, 5))
+rule = MultigoalCCBorda((0, 0))
+# rule = MultigoalTBloc((0, 0))
 
-committee = rule.find_committees(k, profile, method='Bruteforce')
-print('Points:', rule.scores)
+# committee = rule.find_committees(k, profile, method='Bruteforce', criterion='max_appr')
+committee = rule.find_committees(k, profile, method='ILP', criterion='max_appr')
+
 print('Selected committees:', list(committee))

--- a/pmp/rules/multigoal_bloc_borda.py
+++ b/pmp/rules/multigoal_bloc_borda.py
@@ -26,8 +26,8 @@ class MultigoalBlocBorda(MultigoalRule):
         return committee
 
     @algorithm('Bruteforce', 'Exponential.')
-    def _brute_bloc_borda(self, k, profile):
-        return self._brute(k, profile)
+    def _brute_bloc_borda(self, k, profile, criterion='max_appr'):
+        return self._brute(k, profile, criterion=criterion)
 
     @algorithm('ILP', default=True)
     def _ilp(self, k, profile):

--- a/pmp/rules/multigoal_bloc_borda.py
+++ b/pmp/rules/multigoal_bloc_borda.py
@@ -18,11 +18,11 @@ class MultigoalBlocBorda(MultigoalRule):
                                log_errors=log_errors)
         self.weights = weights
 
-    def find_committees(self, k, profile, method=None):
+    def find_committees(self, k, profile, method=None, criterion='max_appr'):
         if method is None:
-            committee = algorithm.registry.default(self, k, profile)
+            committee = algorithm.registry.default(self, k, profile, criterion=criterion)
         else:
-            committee = algorithm.registry.all[method](self, k, profile)
+            committee = algorithm.registry.all[method](self, k, profile, criterion=criterion)
         return committee
 
     @algorithm('Bruteforce', 'Exponential.')
@@ -30,5 +30,5 @@ class MultigoalBlocBorda(MultigoalRule):
         return self._brute(k, profile, criterion=criterion)
 
     @algorithm('ILP', default=True)
-    def _ilp(self, k, profile):
-        return self._ilp_weakly_separable(k, profile)
+    def _ilp(self, k, profile, criterion='max_appr'):
+        return self._ilp_weakly_separable(k, profile, criterion=criterion)

--- a/pmp/rules/multigoal_multibloc.py
+++ b/pmp/rules/multigoal_multibloc.py
@@ -17,18 +17,3 @@ class MultigoalTBloc(MultigoalRule):
                                [ThresholdRule(TBloc(i + 1), t) for i, t in enumerate(thresholds)],
                                log_errors=log_errors)
         self.weights = weights
-
-    def find_committees(self, k, profile, method=None):
-        if method is None:
-            committee = algorithm.registry.default(self, k, profile)
-        else:
-            committee = algorithm.registry.all[method](self, k, profile)
-        return committee
-
-    @algorithm('Bruteforce', 'Exponential.')
-    def _brute_tbloc(self, k, profile):
-        return self._brute(k, profile)
-
-    @algorithm('ILP', default=True)
-    def _ilp_tbloc(self, k, profile):
-        return self._ilp_weakly_separable(k, profile)


### PR DESCRIPTION
Wybieranie który komitet zwrócić (jeśli więcej niż jeden spełnia progi):
* `any` - pierwszy znaleziony (przydatne w problemie decyzyjnym, żeby nie liczyć niepotrzebnie wszystkich)
* `all` - wszystkie (opcja dostępna tylko w `Bruteforce`)
* `max_appr` - maksymalizuje najgorszą aproksymację spośród wszystkich reguł

Testowanie: w `algorithms_multigoal.py` można ustawić niskie progi (np. 0) i zobaczyć co się stanie dla różnych wartości `method` i `criterion`.

Usunąłem rzeczy z `multigoal_multibloc.py`, bo i tak są dziedziczone z `MultigoalRule`