### PR TITLE
Approx pareto

### DIFF
--- a/examples/multigoal/approx/approx_ccb_pareto.py
+++ b/examples/multigoal/approx/approx_ccb_pareto.py
@@ -1,0 +1,44 @@
+from pmp.experiments import generate_uniform
+from pmp.multigoal import MultigoalExperimentConfig, MultigoalExperiment
+from pmp.multigoal.approximation import calculate_approx_ccborda_ratio, draw_approx_ccborda_ratio
+from pmp.multigoal.helpers import get_distribution_name
+from pmp.rules import MultigoalCCBorda
+import os
+
+current_file = os.path.abspath(__file__)
+current_dir = os.path.dirname(current_file)
+
+# Configuration
+k = 10   # committee_size
+m = 100   # candidates number
+n = 100   # voters number
+
+repetitions = 30
+k_ccs = range(0, k+1)
+
+methods = ['Approx_P', 'Approx_Greedy']
+multigoal_rule = MultigoalCCBorda
+distribution = generate_uniform
+
+experiments = []
+for _ in range(repetitions):
+    config = MultigoalExperimentConfig()
+    config.add_candidates(distribution(-3, -3, 3, 3, m, 'None'))
+    config.add_voters(distribution(-3, -3, 3, 3, n, 'None'))
+    config.set_distribution_name(get_distribution_name(distribution))
+
+    experiment = MultigoalExperiment(config)
+    experiment.set_multigoal_election(MultigoalCCBorda, k, percent_thresholds=[0, 0])
+    experiments.append(experiment)
+
+for repetition, experiment in enumerate(experiments):
+    for i, k_cc in enumerate(k_ccs):
+        file_prefix = 'kcc' + str(k_cc)
+        experiment.set_filename(file_prefix)
+        experiment.run(n=1, n_start=repetition+1, methods=methods, k_cc=k_cc, cplex_trials=5,
+                       save_in=False, save_out=False, save_best=True, save_win=True, save_score=True)
+
+out_dir = experiments[0].get_generated_dir_path()
+file_prefixes = ['kcc' + str(k_cc) for k_cc in k_ccs]
+res = calculate_approx_ccborda_ratio(out_dir, file_prefixes, methods, repetitions)
+draw_approx_ccborda_ratio(out_dir, res, methods, k_ccs)

--- a/examples/multigoal/approx/approx_ccb_pareto.py
+++ b/examples/multigoal/approx/approx_ccb_pareto.py
@@ -1,6 +1,7 @@
 from pmp.experiments import generate_uniform
 from pmp.multigoal import MultigoalExperimentConfig, MultigoalExperiment
-from pmp.multigoal.approximation import calculate_approx_ccborda_ratio, draw_approx_ccborda_ratio
+from pmp.multigoal.approximation import calculate_approx_ccborda_ratio, draw_approx_ccborda_ratio, \
+    draw_approx_ccborda_pareto
 from pmp.multigoal.helpers import get_distribution_name
 from pmp.rules import MultigoalCCBorda
 import os
@@ -13,7 +14,7 @@ k = 10   # committee_size
 m = 100   # candidates number
 n = 100   # voters number
 
-repetitions = 30
+repetitions = 60
 k_ccs = range(0, k+1)
 
 methods = ['Approx_P', 'Approx_Greedy']
@@ -41,4 +42,5 @@ for repetition, experiment in enumerate(experiments):
 out_dir = experiments[0].get_generated_dir_path()
 file_prefixes = ['kcc' + str(k_cc) for k_cc in k_ccs]
 res = calculate_approx_ccborda_ratio(out_dir, file_prefixes, methods, repetitions)
-draw_approx_ccborda_ratio(out_dir, res, methods, k_ccs)
+draw_approx_ccborda_ratio(res, methods, k_ccs)
+draw_approx_ccborda_pareto(res, methods, k_ccs)

--- a/pmp/multigoal/approximation.py
+++ b/pmp/multigoal/approximation.py
@@ -4,28 +4,30 @@ import numpy as np
 from pmp.multigoal.helpers import get_distribution_name, read_scores
 
 
+def get_winner_scores(out_dir, file_prefix, method, rep):
+    score_file_name = '{}_{}_{}.score'.format(file_prefix, method, rep)
+    score_file_path = os.path.join(out_dir, score_file_name)
+    return read_scores(score_file_path)
+
+
+def get_best_scores(out_dir, file_prefix, rep):
+    best_file_name = '{}_{}.best'.format(file_prefix, rep)
+    best_file_path = os.path.join(out_dir, best_file_name)
+    return read_scores(best_file_path)
+
+
 def calculate_approx(experiment, methods, reps):
     file_prefix = experiment.filename
     out_dir = experiment.get_generated_dir_path()
     n_rules = experiment.n_rules()
 
-    def get_winner_scores(method, rep):
-        score_file_name = '{}_{}_{}.score'.format(file_prefix, method, rep)
-        score_file_path = os.path.join(out_dir, score_file_name)
-        return read_scores(score_file_path)
-
-    def get_best_scores(rep):
-        best_file_name = '{}_{}.best'.format(file_prefix, rep)
-        best_file_path = os.path.join(out_dir, best_file_name)
-        return read_scores(best_file_path)
-
     res = np.zeros((len(methods), n_rules, reps))
 
     for rep in range(1, reps+1):
-        optimal_scores = get_best_scores(rep)
+        optimal_scores = get_best_scores(out_dir, file_prefix, rep)
 
         for i, method in enumerate(methods):
-            approx_score = get_winner_scores(method, rep)
+            approx_score = get_winner_scores(out_dir, file_prefix, method, rep)
             res[i, :, rep-1] = approx_score / optimal_scores
 
     res = np.min(res, axis=1)
@@ -53,5 +55,37 @@ def draw_approximation_charts(experiment, ms, k_percs, distribution, approximati
         plt.plot(ks, approximations['Approx_P'][im, :])
         plt.legend(['Greedy', 'P'])
         plt.title('Approximation in CC+kB')
+        plt.savefig(filename)
+        plt.clf()
+
+
+def calculate_approx_ccborda_ratio(out_dir, file_prefixes, methods, reps):
+    res = np.zeros((len(methods), len(file_prefixes), 2, reps))
+
+    for rep in range(1, reps+1):
+        optimal_scores = get_best_scores(out_dir, file_prefixes[0], rep)
+
+        for fi, file_prefix in enumerate(file_prefixes):
+            for mi, method in enumerate(methods):
+                approx_score = get_winner_scores(out_dir, file_prefix, method, rep)
+                res[mi, fi, :, rep-1] = approx_score / optimal_scores
+
+    res = np.mean(res, axis=3)
+    return res
+
+
+def draw_approx_ccborda_ratio(out_dir, res, methods, k_ccs):
+    for mi, method in enumerate(methods):
+        filename = os.path.join(out_dir, 'approx_{}'.format(method))
+
+        axes = plt.gca()
+        axes.set_ylim([0, 1.1])
+        plt.xlabel('Committee members selected by CC')
+        plt.ylabel('approximation')
+
+        plt.plot(k_ccs, res[mi, :, 0])
+        plt.plot(k_ccs, res[mi, :, 1])
+        plt.legend(['CC', 'kB'])
+        plt.title('Approximation in CC+kB ({})'.format(method))
         plt.savefig(filename)
         plt.clf()

--- a/pmp/multigoal/approximation.py
+++ b/pmp/multigoal/approximation.py
@@ -70,13 +70,14 @@ def calculate_approx_ccborda_ratio(out_dir, file_prefixes, methods, reps):
                 approx_score = get_winner_scores(out_dir, file_prefix, method, rep)
                 res[mi, fi, :, rep-1] = approx_score / optimal_scores
 
-    res = np.mean(res, axis=3)
     return res
 
 
-def draw_approx_ccborda_ratio(out_dir, res, methods, k_ccs):
+def draw_approx_ccborda_ratio(res, methods, k_ccs):
+    res = np.mean(res, axis=3)
+
     for mi, method in enumerate(methods):
-        filename = os.path.join(out_dir, 'approx_{}'.format(method))
+        filename = 'approx_{}'.format(method)
 
         axes = plt.gca()
         axes.set_ylim([0, 1.1])
@@ -86,6 +87,27 @@ def draw_approx_ccborda_ratio(out_dir, res, methods, k_ccs):
         plt.plot(k_ccs, res[mi, :, 0])
         plt.plot(k_ccs, res[mi, :, 1])
         plt.legend(['CC', 'kB'])
+        plt.title('Approximation in CC+kB ({})'.format(method))
+        plt.savefig(filename)
+        plt.clf()
+
+
+def draw_approx_ccborda_pareto(res, methods, k_ccs):
+    res = np.min(res, axis=3)
+    k_ccs = ['   k_CC={}'.format(kcc) for kcc in k_ccs]
+
+    for mi, method in enumerate(methods):
+        filename = 'approx_pareto_{}'.format(method)
+
+        # axes = plt.gca()
+        # axes.set_xlim([0, 1.1])
+        # axes.set_ylim([0, 1.1])
+        plt.xlabel('CC')
+        plt.ylabel('k-Borda')
+
+        plt.plot(res[mi, :, 0], res[mi, :, 1], '.-')
+        for ki, k_cc in enumerate(k_ccs):
+            plt.annotate(k_cc, (res[mi, ki, 0], res[mi, ki, 1]), fontsize='xx-small')
         plt.title('Approximation in CC+kB ({})'.format(method))
         plt.savefig(filename)
         plt.clf()

--- a/pmp/rules/multigoal_cc_borda.py
+++ b/pmp/rules/multigoal_cc_borda.py
@@ -129,8 +129,11 @@ class MultigoalCCBorda(MultigoalRule):
         return committee
 
     @algorithm('Approx_Greedy')
-    def _greedy(self, k, profile, criterion='max_appr'):
-        k_cc = int(np.ceil(np.real(lambertw(1)) * k))
+    def _greedy(self, k, profile, l_cc=None, criterion='max_appr'):
+        if l_cc is None:
+            l_cc = np.real(lambertw(1))
+
+        k_cc = int(np.ceil(l_cc * k))
         # print('Greedy: selecting {} candidates with CC Greedy and {} candidates with Borda'.format(k_cc, k - k_cc))
 
         committee = set(self.rules[0].rule.find_committee(k_cc, profile, method='Approx_Greedy'))
@@ -144,14 +147,16 @@ class MultigoalCCBorda(MultigoalRule):
                 return committee
 
     @algorithm('Approx_P')
-    def _p(self, k, profile, criterion='max_appr'):
-        x = int(np.math.ceil(profile.num_cand * np.real(lambertw(k)) / k))
-        A = 1 - (np.real(lambertw(k))) / k
-        M = 1 - (profile.num_cand - x) / (profile.num_cand - 1)
-        C = np.log(A) * k * (M - 1) * np.power(A, k * M)
-        l_cc = M - np.real(lambertw(C)) / (np.log(A) * k)
+    def _p(self, k, profile, l_cc=None, criterion='max_appr'):
+        if l_cc is None:
+            x = int(np.math.ceil(profile.num_cand * np.real(lambertw(k)) / k))
+            A = 1 - (np.real(lambertw(k))) / k
+            M = 1 - (profile.num_cand - x) / (profile.num_cand - 1)
+            C = np.log(A) * k * (M - 1) * np.power(A, k * M)
+            l_cc = M - np.real(lambertw(C)) / (np.log(A) * k)
+
         k_cc = int(np.ceil(l_cc * k))
-        # print('P: selecting {} candidates with CC Greedy and {} candidates with Borda'.format(k_cc, k - k_cc))
+        # print('P: selecting {} candidates with CC Alg-P and {} candidates with Borda'.format(k_cc, k - k_cc))
 
         committee = self.rules[0].rule.find_committee(k, profile, method='Approx_P')
         committee = set(committee[:k_cc])

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setup(name='pmp',
       license='?',
       packages=setuptools.find_packages(),
       install_requires=[
-          'matplotlib', 'numpy', 'cplex'],
+          'matplotlib', 'numpy', 'cplex', 'scipy'],
       zip_safe=False)
 


### PR DESCRIPTION
* Algorytmy aproksymacyjne dla CC+kB pozwalają teraz na podanie z góry ilu kandydatów ma wybrać CC, a ile kB
* Wykresy pokazujące aproksymację obu reguł w zależności od tego ilu kandydatów wybierzemy którym algorytmem (`approx_ccb_pareto.py`)